### PR TITLE
domd: Remove weston patches which cause the weston crash

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
@@ -16,6 +16,12 @@ SRC_URI_append = "file://weston-seats.rules \
                   file://weston-seats-kf.rules \
 "
 
+# 0002-compositor-add-output-type-to-weston_output.patch       cases weston crash
+# 0003-compositor-drm-introduce-drm_get_dmafd_from_view.patch  add not used function
+SRC_URI_remove = "file://0002-compositor-add-output-type-to-weston_output.patch \
+                  file://0003-compositor-drm-introduce-drm_get_dmafd_from_view.patch \
+"
+
 FILES_${PN} += " \
     ${sysconfdir}/udev/rules.d/weston-seats.rules \
 "


### PR DESCRIPTION
There are weston patches in AGL layer which causes weston crash on KF
board. It is unclear for what these patches stand. Remove them till better
solution.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>