### PR TITLE
dev86-native: Use github link for SRC_URI

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/dev86/dev86_%.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/dev86/dev86_%.bbappend
@@ -1,0 +1,5 @@
+
+SRC_URI="https://github.com/lkundrak/dev86/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "288af53f256300777efc91d97c082fda"
+SRC_URI[sha256sum] = "533f2a0d2ed61223040f27e5cd007a11d969aaf34f6b709ece122b1e6fc50580"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/dev86/dev86_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/dev86/dev86_%.bbappend
@@ -1,0 +1,5 @@
+
+SRC_URI="https://github.com/lkundrak/dev86/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "288af53f256300777efc91d97c082fda"
+SRC_URI[sha256sum] = "533f2a0d2ed61223040f27e5cd007a11d969aaf34f6b709ece122b1e6fc50580"


### PR DESCRIPTION
Ported from prod-devel

Temporary solution until error below is fixed.

This site can’t be reached
v3.sk took too long to respond.
Search Google for sk ~lkundrak dev86 archive Dev86src tar
ERR_CONNECTION_TIMED_OUT

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>